### PR TITLE
feat: redesign portfolio with terminal aesthetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,59 @@
-# Júlio Silva - Portfolio Website
+# Júlio Silva — Portfolio
 
-A professional portfolio website showcasing my skills, experience, and projects as a Software Engineer.
+A personal portfolio site showcasing my skills, experience, and projects as a Backend Engineer.
+Single static page, built with vanilla HTML, CSS, and JavaScript — no frameworks, no build step.
+
+Live: https://jmbcs.github.io/portfolio/
 
 ## Features
 
-- **Responsive Design**: Works on all devices and screen sizes
-- **Light/Dark Mode**: Toggle between light and dark themes
-- **Animations**: Smooth animations when scrolling and opening the website
-- **Type Animation**: Dynamic text typing effect in the hero section
-- **Interactive Elements**: Hover effects and interactive components
-- **Contact Form**: Fully functional contact form
-- **Modern UI**: Clean and professional interface
+- **Technical/terminal aesthetic**: monospace accents, precise grid, dark-first palette with a single blue accent
+- **Light/dark mode**: persisted to `localStorage`, applied before first paint (no flash)
+- **Responsive**: mobile-first, works across phone, tablet, and desktop
+- **Tasteful animations**: staggered scroll reveals, hover lifts; fully disabled under `prefers-reduced-motion`
+- **Accessible**: keyboard focus indicators, skip link, labelled form fields, ARIA on icon-only controls
+- **SEO ready**: Open Graph / Twitter Card metadata, canonical URL, and `Person` JSON-LD structured data
+- **Contact form**: submits to Formspree with inline success/error states
 
-## Technologies Used
+## Technologies
 
 - HTML5
-- CSS3
-- JavaScript (Vanilla)
-- Font Awesome (for icons)
-- Google Fonts
+- CSS3 (custom properties, Grid, Flexbox)
+- Vanilla JavaScript (IntersectionObserver, `requestAnimationFrame`-throttled scroll)
+- Inline SVG icons (no icon-font dependency)
+- Google Fonts — Inter (body) and JetBrains Mono (accents)
 
 ## Sections
 
-1. **Home**: Introduction with animated typing text
-2. **About**: Personal information and interests
-3. **Experience**: Work history with timeline
-4. **Skills**: Technical skills organized by category
-5. **Projects**: Featured projects with descriptions and links
-6. **Education**: Academic background and relevant links
-7. **Languages**: Language proficiency with progress bars
-8. **Contact**: Contact information and form
+1. **Hero** — intro and primary calls to action
+2. **About** — background and key details
+3. **Experience** — work history as a timeline
+4. **Skills** — technical skills by category (core stack highlighted)
+5. **Projects** — selected projects with links
+6. **Additional** — relevant links and languages
+7. **Contact** — direct links and a contact form
 
-## Setup and Installation
+## Run locally
 
-1. Clone the repository:
-   ```
-   git clone https://github.com/jmbcs/portfolio.git
-   ```
-
-2. Navigate to the project directory:
-   ```
-   cd portfolio
-   ```
-
-3. Open `index.html` in your browser or use a local server:
-   ```
-   python -m http.server
-   ```
+```bash
+git clone https://github.com/jmbcs/portfolio.git
+cd portfolio
+python -m http.server 8000
+# open http://localhost:8000
+```
 
 ## Customization
 
-To customize the portfolio for your own use:
-
-1. Replace personal information in `index.html`
-2. Update project details and images
-3. Modify the color scheme in `styles.css` by changing the CSS variables
-4. Adjust animations and effects in `script.js` as needed
-
-## Development
-
-- The website is built with vanilla JavaScript for optimal performance
-- CSS variables are used for consistent theming
-- Responsive design implemented with CSS Grid and Flexbox
-- Animations are created using CSS transitions and keyframes
+- Content and metadata: `index.html` (including the `<head>` SEO/OG tags and JSON-LD)
+- Theme tokens (colors, spacing, type scale): the `:root` / `[data-theme="dark"]` blocks in `styles.css`
+- Behavior (theme toggle, nav, reveals, form): `script.js`
 
 ## License
 
-This project is open source and available under the [MIT License](LICENSE).
+Open source under the [MIT License](LICENSE).
 
 ## Contact
 
-Júlio Silva - [julio.m.b.c.silva@gmail.com](mailto:julio.m.b.c.silva@gmail.com)
+Júlio Silva — [julio.m.b.c.silva@gmail.com](mailto:julio.m.b.c.silva@gmail.com)
 
-Project Link: [https://github.com/jmbcs/portfolio](https://github.com/jmbcs/portfolio)
+Project link: [https://github.com/jmbcs/portfolio](https://github.com/jmbcs/portfolio)

--- a/index.html
+++ b/index.html
@@ -4,31 +4,126 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Júlio Silva — Backend Engineer</title>
-    <meta name="description" content="Backend engineer with 4+ years building production systems — REST APIs, OTA channel integrations, and distributed event pipelines. Python, Django, Go. Based in Portugal, working remotely." />
-    <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'dark')</script>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%232563eb'><path d='M3 3h18a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zm1 2v14h16V5H4zm8 10a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm-3-1a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm6 0a1 1 0 1 1 0-2 1 1 0 0 1 0 2z'/></svg>" type="image/svg+xml" />
+    <meta
+      name="description"
+      content="Backend engineer with six years building production systems — REST APIs, OTA channel integrations, and distributed event pipelines across Booking.com, Airbnb, and Vrbo. Python, Django, Go. Based in Portugal, working remotely."
+    />
+    <meta name="author" content="Júlio Silva" />
+    <meta name="theme-color" content="#0a0a0b" />
+
+    <!-- Set theme before paint to avoid flash -->
+    <script>
+      document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'dark')
+    </script>
+
+    <!-- Canonical & social -->
+    <link rel="canonical" href="https://jmbcs.github.io/portfolio/" />
+    <meta property="og:type" content="profile" />
+    <meta property="og:title" content="Júlio Silva — Backend Engineer" />
+    <meta
+      property="og:description"
+      content="Backend engineer with six years building production systems — REST APIs, OTA channel integrations, and distributed event pipelines. Python, Django, Go."
+    />
+    <meta property="og:url" content="https://jmbcs.github.io/portfolio/" />
+    <meta property="og:image" content="https://jmbcs.github.io/portfolio/imgs/profile.jpg" />
+    <meta property="og:image:alt" content="Júlio Silva" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="profile:first_name" content="Júlio" />
+    <meta property="profile:last_name" content="Silva" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Júlio Silva — Backend Engineer" />
+    <meta
+      name="twitter:description"
+      content="Backend engineer with six years building production systems — REST APIs, OTA channel integrations, and distributed event pipelines. Python, Django, Go."
+    />
+    <meta name="twitter:image" content="https://jmbcs.github.io/portfolio/imgs/profile.jpg" />
+
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%2358a6ff'><path d='M3 3h18a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zm1 2v14h16V5H4zm8 10a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm-3-1a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm6 0a1 1 0 1 1 0-2 1 1 0 0 1 0 2z'/></svg>"
+      type="image/svg+xml"
+    />
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="styles.css" />
+
+    <!-- Structured data: Person -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "Júlio Silva",
+        "jobTitle": "Backend Engineer",
+        "url": "https://jmbcs.github.io/portfolio/",
+        "image": "https://jmbcs.github.io/portfolio/imgs/profile.jpg",
+        "email": "mailto:julio.m.b.c.silva@gmail.com",
+        "worksFor": { "@type": "Organization", "name": "GuestReady" },
+        "alumniOf": { "@type": "CollegeOrUniversity", "name": "University of Aveiro" },
+        "address": { "@type": "PostalAddress", "addressLocality": "Viseu", "addressCountry": "PT" },
+        "knowsLanguage": ["pt", "en"],
+        "knowsAbout": [
+          "Python", "Go", "Django", "FastAPI", "PostgreSQL", "Redis",
+          "Distributed Systems", "REST APIs", "gRPC", "Event-driven architecture"
+        ],
+        "sameAs": [
+          "https://github.com/jmbcs",
+          "https://linkedin.com/in/julio-miguel-silva"
+        ]
+      }
+    </script>
   </head>
   <body>
+    <a href="#main" class="skip-link">Skip to content</a>
+
+    <!-- Icon sprite (inline SVG; replaces Font Awesome) -->
+    <svg class="sprite" aria-hidden="true" focusable="false" width="0" height="0">
+      <symbol id="i-github" viewBox="0 0 24 24">
+        <path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+      </symbol>
+      <symbol id="i-linkedin" viewBox="0 0 24 24">
+        <path fill="currentColor" d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+      </symbol>
+      <symbol id="i-youtube" viewBox="0 0 24 24">
+        <path fill="currentColor" d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+      </symbol>
+      <symbol id="i-mail" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="2" y="4" width="20" height="16" rx="2" />
+        <path d="m22 7-10 6L2 7" />
+      </symbol>
+      <symbol id="i-external" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+        <path d="M15 3h6v6" />
+        <path d="M10 14 21 3" />
+      </symbol>
+      <symbol id="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="4" />
+        <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+      </symbol>
+      <symbol id="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+      </symbol>
+    </svg>
+
     <nav id="nav">
       <div class="nav-inner">
-        <a href="#hero" class="nav-logo">JS</a>
+        <a href="#hero" class="nav-logo" aria-label="Home">js<span class="accent">_</span></a>
         <ul class="nav-links">
-          <li><a href="#about">About</a></li>
-          <li><a href="#experience">Experience</a></li>
-          <li><a href="#skills">Skills</a></li>
-          <li><a href="#projects">Projects</a></li>
-          <li><a href="#contact">Contact</a></li>
+          <li><a href="#about">about</a></li>
+          <li><a href="#experience">experience</a></li>
+          <li><a href="#skills">skills</a></li>
+          <li><a href="#projects">projects</a></li>
+          <li><a href="#contact">contact</a></li>
         </ul>
         <div class="nav-actions">
-          <button class="theme-toggle" aria-label="Toggle theme">
-            <i id="theme-icon" class="fas fa-sun"></i>
+          <button class="theme-toggle" aria-label="Toggle theme" aria-pressed="true">
+            <svg class="icon" aria-hidden="true"><use href="#i-sun" /></svg>
           </button>
-          <button class="nav-toggle" aria-label="Toggle menu">
+          <button class="nav-toggle" aria-label="Toggle menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
@@ -37,35 +132,36 @@
       </div>
     </nav>
 
-    <main>
+    <main id="main">
       <!-- Hero -->
       <section id="hero">
         <div class="container">
-          <p class="hero-label">Backend Engineer</p>
+          <p class="hero-label">~/ backend-engineer<span class="caret" aria-hidden="true"></span></p>
           <h1>Júlio Silva</h1>
           <p class="hero-desc">
-            I build production-grade backend systems — REST APIs, OTA channel integrations,
-            and distributed event pipelines. Python, Django, and Go.
+            I build production-grade backend systems — REST APIs, OTA channel integrations, and
+            distributed event pipelines that keep thousands of short-term rental properties in
+            sync across Booking.com, Airbnb, and Vrbo. Python, Django, and Go.
           </p>
           <div class="hero-cta">
-            <a href="#contact" class="btn btn-primary">Get in touch</a>
+            <a href="#contact" class="btn btn-primary">get in touch</a>
             <a
               href="https://github.com/jmbcs/curriculum/blob/main/output/CV_JULIO_SILVA.pdf"
               target="_blank"
               rel="noopener"
-              class="btn btn-outline"
-              >View CV</a
+              class="btn btn-ghost"
+              >view cv <span class="arrow" aria-hidden="true">→</span></a
             >
           </div>
           <div class="hero-socials">
             <a href="https://github.com/jmbcs" target="_blank" rel="noopener" aria-label="GitHub">
-              <i class="fab fa-github"></i>
+              <svg class="icon" aria-hidden="true"><use href="#i-github" /></svg>
             </a>
             <a href="https://linkedin.com/in/julio-miguel-silva" target="_blank" rel="noopener" aria-label="LinkedIn">
-              <i class="fab fa-linkedin"></i>
+              <svg class="icon" aria-hidden="true"><use href="#i-linkedin" /></svg>
             </a>
             <a href="mailto:julio.m.b.c.silva@gmail.com" aria-label="Email">
-              <i class="fas fa-envelope"></i>
+              <svg class="icon" aria-hidden="true"><use href="#i-mail" /></svg>
             </a>
           </div>
         </div>
@@ -74,46 +170,46 @@
       <!-- About -->
       <section id="about">
         <div class="container">
-          <h2 class="section-label">About</h2>
+          <h2 class="section-label"><span class="idx">01</span> about</h2>
           <div class="about-grid">
             <div class="about-photo">
-              <img src="imgs/profile.jpg" alt="Júlio Silva" width="200" height="200" />
+              <img src="imgs/profile.jpg" alt="Júlio Silva" width="779" height="1038" />
+              <span class="photo-caption">profile.jpg</span>
             </div>
             <div class="about-text">
               <p>
-                Backend software engineer with 4+ years of production experience. I specialize
-                in API design, distributed systems, and performance-critical backends — building
-                services that stay reliable under load, integrate cleanly with external systems,
-                and remain maintainable as they scale.
+                Backend engineer with six years of production experience, focused on API design,
+                distributed systems, and performance-critical services — the kind that stay
+                reliable under load, integrate cleanly with external systems, and remain
+                maintainable as they scale.
               </p>
               <p>
-                Currently at GuestReady/RentalReady, contributing to a Django-based property
-                management platform that orchestrates availability, pricing, and channel
-                distribution for thousands of properties across Booking.com, Airbnb, and Vrbo.
-                Previously at Wavecom, I designed microservices in Python and Go, built
-                real-time monitoring infrastructure for HPC clusters, and delivered ETL
+                Currently at GuestReady / RentalReady, building integration and pricing features
+                for a Django-based property management platform that orchestrates availability,
+                rates, and channel distribution for thousands of properties across Booking.com,
+                Airbnb, and Vrbo. Previously at Wavecom, I designed microservices in Python and Go,
+                built real-time monitoring infrastructure for HPC clusters, and delivered ETL
                 pipelines from greenfield to production.
               </p>
               <p>
-                I care about the hard parts: data consistency, service boundaries, database
-                performance, and clean API contracts. Working towards a technical leadership
-                track — writing code every day, and leveraging AI tools like Claude Code and
-                Cursor to stay sharp and ship faster.
+                I care about the hard parts — data consistency, service boundaries, database
+                performance, and clean API contracts — and I write code every day, using AI tools
+                like Claude Code and Cursor to move faster without losing the thread.
               </p>
-              <div class="about-details">
+              <dl class="about-details">
                 <div>
-                  <span class="detail-label">Location</span>
-                  Viseu, Portugal
+                  <dt>location</dt>
+                  <dd>Viseu, Portugal</dd>
                 </div>
                 <div>
-                  <span class="detail-label">Role</span>
-                  Backend Engineer at GuestReady / RentalReady
+                  <dt>role</dt>
+                  <dd>Backend Engineer @ GuestReady / RentalReady</dd>
                 </div>
                 <div>
-                  <span class="detail-label">Education</span>
-                  M.Sc Electronics &amp; Telecommunications, University of Aveiro
+                  <dt>education</dt>
+                  <dd>M.Sc Electronics &amp; Telecommunications, University of Aveiro</dd>
                 </div>
-              </div>
+              </dl>
             </div>
           </div>
         </div>
@@ -122,7 +218,7 @@
       <!-- Experience -->
       <section id="experience">
         <div class="container">
-          <h2 class="section-label">Experience</h2>
+          <h2 class="section-label"><span class="idx">02</span> experience</h2>
           <div class="timeline">
             <div class="timeline-item">
               <div class="timeline-meta">
@@ -133,14 +229,13 @@
                 <h3>Backend Engineer</h3>
                 <p class="timeline-org">GuestReady / RentalReady</p>
                 <ul>
-                  <li>Building features for a Django-based PMS serving thousands of short-term rental properties across global OTA channels</li>
-                  <li>Built and maintained live channel integrations with Booking.com, Airbnb, and Vrbo — real-time sync of availability, rates, and reservations</li>
+                  <li>Built and maintained live channel integrations with Booking.com, Airbnb, and Vrbo — real-time sync of availability, rates, and reservations for thousands of short-term rental properties</li>
                   <li>Delivered promotions features connecting GuestReady to Airbnb, Vrbo, and Booking.com, enabling dynamic discount campaigns across OTA channels</li>
-                  <li>Implemented monitoring alarms in New Relic for proactive production observability and incident response</li>
-                  <li>Improved processing efficiency with a Redis hash-based deduplication layer that prevents reprocessing of stale events</li>
-                  <li>Triaging production incidents with Sentry and Datadog; running zero-downtime bulk operations on large PostgreSQL tables</li>
-                  <li>Maintaining engineering quality through code review in a distributed team of 40+ engineers</li>
-                  <li>Accelerating development workflows with AI coding tools (Claude Code, Cursor)</li>
+                  <li>Built a Redis hash-based deduplication layer that prevents reprocessing of stale events, cutting redundant work in the channel pipeline</li>
+                  <li>Implemented New Relic monitoring alarms for proactive production observability and faster incident response</li>
+                  <li>Triaged production incidents with Sentry and Datadog; ran zero-downtime bulk operations on large PostgreSQL tables</li>
+                  <li>Maintained engineering quality through code review on a distributed team of 40+ engineers</li>
+                  <li>Accelerated delivery with AI coding tools (Claude Code, Cursor)</li>
                 </ul>
                 <div class="tag-row">
                   <span>Django</span><span>PostgreSQL</span><span>Redis</span><span>Sentry</span><span>Datadog</span><span>New Relic</span><span>REST APIs</span>
@@ -178,8 +273,7 @@
                 <h3>M.Sc Electronics &amp; Telecommunications Engineering</h3>
                 <p class="timeline-org">University of Aveiro</p>
                 <p class="timeline-note">
-                  <strong>Thesis:</strong> Recovery and Identification of Moments
-                  — Grade: 19/20
+                  <strong>Thesis:</strong> Recovery and Identification of Moments — Grade: 19/20
                 </p>
                 <ul>
                   <li>Developed a Python image retrieval system associating images to moments described in natural language text</li>
@@ -193,24 +287,25 @@
       <!-- Skills -->
       <section id="skills">
         <div class="container">
-          <h2 class="section-label">Skills</h2>
+          <h2 class="section-label"><span class="idx">03</span> skills</h2>
+          <p class="section-note">Core stack <span class="primary-marker">highlighted</span>.</p>
           <div class="skills-grid">
             <div class="skill-group">
               <h3>Languages</h3>
               <div class="tag-row">
-                <span>Python</span><span>Go</span><span>SQL</span>
+                <span class="primary">Python</span><span class="primary">Go</span><span>SQL</span>
               </div>
             </div>
             <div class="skill-group">
               <h3>Frameworks</h3>
               <div class="tag-row">
-                <span>Django</span><span>FastAPI</span><span>SQLAlchemy</span><span>Pandas</span>
+                <span class="primary">Django</span><span class="primary">FastAPI</span><span>SQLAlchemy</span><span>Pandas</span>
               </div>
             </div>
             <div class="skill-group">
               <h3>Databases</h3>
               <div class="tag-row">
-                <span>PostgreSQL</span><span>Redis</span><span>VictoriaMetrics</span>
+                <span class="primary">PostgreSQL</span><span class="primary">Redis</span><span>VictoriaMetrics</span>
               </div>
             </div>
             <div class="skill-group">
@@ -222,7 +317,7 @@
             <div class="skill-group">
               <h3>Infrastructure</h3>
               <div class="tag-row">
-                <span>Docker</span><span>Linux</span>
+                <span class="primary">Docker</span><span>Linux</span><span>AWS</span>
               </div>
             </div>
             <div class="skill-group">
@@ -250,14 +345,14 @@
       <!-- Projects -->
       <section id="projects">
         <div class="container">
-          <h2 class="section-label">Projects</h2>
+          <h2 class="section-label"><span class="idx">04</span> projects</h2>
           <div class="projects-grid">
             <div class="project-card">
               <div class="project-top">
-                <h3>TaskMate</h3>
+                <h3><span class="card-idx">01</span>TaskMate</h3>
                 <div class="project-links">
-                  <a href="https://github.com/jmbcs/taskmate" target="_blank" rel="noopener" aria-label="GitHub">
-                    <i class="fab fa-github"></i>
+                  <a href="https://github.com/jmbcs/taskmate" target="_blank" rel="noopener" aria-label="TaskMate on GitHub">
+                    <svg class="icon" aria-hidden="true"><use href="#i-github" /></svg>
                   </a>
                 </div>
               </div>
@@ -269,10 +364,10 @@
 
             <div class="project-card">
               <div class="project-top">
-                <h3>prod-killer</h3>
+                <h3><span class="card-idx">02</span>prod-killer</h3>
                 <div class="project-links">
-                  <a href="https://github.com/jmbcs/prod-killer" target="_blank" rel="noopener" aria-label="GitHub">
-                    <i class="fab fa-github"></i>
+                  <a href="https://github.com/jmbcs/prod-killer" target="_blank" rel="noopener" aria-label="prod-killer on GitHub">
+                    <svg class="icon" aria-hidden="true"><use href="#i-github" /></svg>
                   </a>
                 </div>
               </div>
@@ -284,13 +379,13 @@
 
             <div class="project-card">
               <div class="project-top">
-                <h3>BigHPC</h3>
+                <h3><span class="card-idx">03</span>BigHPC</h3>
                 <div class="project-links">
-                  <a href="https://www.youtube.com/watch?v=5gaiovo9DD0" target="_blank" rel="noopener" aria-label="Video">
-                    <i class="fab fa-youtube"></i>
+                  <a href="https://www.youtube.com/watch?v=5gaiovo9DD0" target="_blank" rel="noopener" aria-label="BigHPC conference talk">
+                    <svg class="icon" aria-hidden="true"><use href="#i-youtube" /></svg>
                   </a>
-                  <a href="https://bighpc.wavecom.pt/" target="_blank" rel="noopener" aria-label="Website">
-                    <i class="fas fa-arrow-up-right-from-square"></i>
+                  <a href="https://bighpc.wavecom.pt/" target="_blank" rel="noopener" aria-label="BigHPC website">
+                    <svg class="icon" aria-hidden="true"><use href="#i-external" /></svg>
                   </a>
                 </div>
               </div>
@@ -302,10 +397,10 @@
 
             <div class="project-card">
               <div class="project-top">
-                <h3>Portfolio</h3>
+                <h3><span class="card-idx">04</span>Portfolio</h3>
                 <div class="project-links">
-                  <a href="https://github.com/jmbcs/portfolio" target="_blank" rel="noopener" aria-label="GitHub">
-                    <i class="fab fa-github"></i>
+                  <a href="https://github.com/jmbcs/portfolio" target="_blank" rel="noopener" aria-label="Portfolio on GitHub">
+                    <svg class="icon" aria-hidden="true"><use href="#i-github" /></svg>
                   </a>
                 </div>
               </div>
@@ -317,10 +412,10 @@
 
             <div class="project-card">
               <div class="project-top">
-                <h3>RentalReady</h3>
+                <h3><span class="card-idx">05</span>RentalReady</h3>
                 <div class="project-links">
-                  <a href="https://www.rentalready.com/" target="_blank" rel="noopener" aria-label="Website">
-                    <i class="fas fa-arrow-up-right-from-square"></i>
+                  <a href="https://www.rentalready.com/" target="_blank" rel="noopener" aria-label="RentalReady website">
+                    <svg class="icon" aria-hidden="true"><use href="#i-external" /></svg>
                   </a>
                 </div>
               </div>
@@ -336,7 +431,7 @@
       <!-- Additional Info -->
       <section id="additional">
         <div class="container">
-          <h2 class="section-label">Additional</h2>
+          <h2 class="section-label"><span class="idx">05</span> additional</h2>
           <div class="additional-grid">
             <div>
               <h3 class="sub-label">Relevant Links</h3>
@@ -344,25 +439,25 @@
                 <li>
                   <a href="https://bighpc.wavecom.pt/" target="_blank" rel="noopener">
                     BigHPC — Project Website
-                    <i class="fas fa-arrow-up-right-from-square"></i>
+                    <svg class="icon" aria-hidden="true"><use href="#i-external" /></svg>
                   </a>
                 </li>
                 <li>
                   <a href="https://www.youtube.com/watch?v=5gaiovo9DD0" target="_blank" rel="noopener">
                     BigHPC — Conference Talk
-                    <i class="fas fa-arrow-up-right-from-square"></i>
+                    <svg class="icon" aria-hidden="true"><use href="#i-external" /></svg>
                   </a>
                 </li>
                 <li>
                   <a href="https://ria.ua.pt/handle/10773/30553" target="_blank" rel="noopener">
                     Thesis — UA Repository
-                    <i class="fas fa-arrow-up-right-from-square"></i>
+                    <svg class="icon" aria-hidden="true"><use href="#i-external" /></svg>
                   </a>
                 </li>
                 <li>
                   <a href="https://ceur-ws.org/Vol-2696/paper_91.pdf" target="_blank" rel="noopener">
                     Thesis Paper — CEUR Proceedings
-                    <i class="fas fa-arrow-up-right-from-square"></i>
+                    <svg class="icon" aria-hidden="true"><use href="#i-external" /></svg>
                   </a>
                 </li>
               </ul>
@@ -387,31 +482,40 @@
       <!-- Contact -->
       <section id="contact">
         <div class="container">
-          <h2 class="section-label">Contact</h2>
-          <p class="contact-intro">Open to backend engineering and technical lead roles. Based in Portugal — fully remote, available immediately.</p>
+          <h2 class="section-label"><span class="idx">06</span> contact</h2>
+          <p class="contact-intro">
+            Open to backend engineering and technical lead roles. Based in Portugal — fully remote.
+          </p>
           <div class="contact-grid">
             <div class="contact-info">
               <a href="mailto:julio.m.b.c.silva@gmail.com" class="contact-link">
-                <i class="fas fa-envelope"></i>
+                <svg class="icon" aria-hidden="true"><use href="#i-mail" /></svg>
                 <span>julio.m.b.c.silva@gmail.com</span>
               </a>
               <a href="https://github.com/jmbcs" target="_blank" rel="noopener" class="contact-link">
-                <i class="fab fa-github"></i>
+                <svg class="icon" aria-hidden="true"><use href="#i-github" /></svg>
                 <span>github.com/jmbcs</span>
               </a>
               <a href="https://linkedin.com/in/julio-miguel-silva" target="_blank" rel="noopener" class="contact-link">
-                <i class="fab fa-linkedin"></i>
+                <svg class="icon" aria-hidden="true"><use href="#i-linkedin" /></svg>
                 <span>linkedin.com/in/julio-miguel-silva</span>
               </a>
             </div>
             <form id="contact-form">
               <div class="form-row">
-                <input type="text" name="name" placeholder="Name" required autocomplete="name" />
-                <input type="email" name="email" placeholder="Email" required autocomplete="email" />
+                <div class="field">
+                  <label for="name" class="sr-only">Name</label>
+                  <input id="name" type="text" name="name" placeholder="Name" required autocomplete="name" />
+                </div>
+                <div class="field">
+                  <label for="email" class="sr-only">Email</label>
+                  <input id="email" type="email" name="email" placeholder="Email" required autocomplete="email" />
+                </div>
               </div>
-              <textarea name="message" placeholder="Message" rows="5" required></textarea>
+              <label for="message" class="sr-only">Message</label>
+              <textarea id="message" name="message" placeholder="Message" rows="5" required></textarea>
               <button type="submit" id="submit-btn">
-                <span class="btn-text">Send message</span>
+                <span class="btn-text">send message</span>
               </button>
             </form>
           </div>
@@ -422,16 +526,17 @@
     <footer>
       <div class="container">
         <div class="footer-inner">
-          <span class="footer-name">Júlio Silva</span>
+          <span class="footer-name">© 2026 Júlio Silva</span>
+          <span class="footer-built">built with vanilla html · css · js</span>
           <div class="footer-socials">
             <a href="https://github.com/jmbcs" target="_blank" rel="noopener" aria-label="GitHub">
-              <i class="fab fa-github"></i>
+              <svg class="icon" aria-hidden="true"><use href="#i-github" /></svg>
             </a>
             <a href="https://linkedin.com/in/julio-miguel-silva" target="_blank" rel="noopener" aria-label="LinkedIn">
-              <i class="fab fa-linkedin"></i>
+              <svg class="icon" aria-hidden="true"><use href="#i-linkedin" /></svg>
             </a>
             <a href="mailto:julio.m.b.c.silva@gmail.com" aria-label="Email">
-              <i class="fas fa-envelope"></i>
+              <svg class="icon" aria-hidden="true"><use href="#i-mail" /></svg>
             </a>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Júlio Silva — Backend Engineer</title>
+    <meta name="description" content="Backend engineer with 4+ years building production systems — REST APIs, OTA channel integrations, and distributed event pipelines. Python, Django, Go. Based in Portugal, working remotely." />
     <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'dark')</script>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%232563eb'><path d='M3 3h18a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zm1 2v14h16V5H4zm8 10a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm-3-1a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm6 0a1 1 0 1 1 0-2 1 1 0 0 1 0 2z'/></svg>" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -43,8 +44,8 @@
           <p class="hero-label">Backend Engineer</p>
           <h1>Júlio Silva</h1>
           <p class="hero-desc">
-            I design and build backend systems that scale — REST APIs, distributed services,
-            and data pipelines using Python, Django, and Go.
+            I build production-grade backend systems — REST APIs, OTA channel integrations,
+            and distributed event pipelines. Python, Django, and Go.
           </p>
           <div class="hero-cta">
             <a href="#contact" class="btn btn-primary">Get in touch</a>
@@ -96,7 +97,8 @@
               <p>
                 I care about the hard parts: data consistency, service boundaries, database
                 performance, and clean API contracts. Working towards a technical leadership
-                track — writing code every day.
+                track — writing code every day, and leveraging AI tools like Claude Code and
+                Cursor to stay sharp and ship faster.
               </p>
               <div class="about-details">
                 <div>
@@ -131,13 +133,17 @@
                 <h3>Backend Engineer</h3>
                 <p class="timeline-org">GuestReady / RentalReady</p>
                 <ul>
-                  <li>Contributing to a Django-based PMS serving thousands of short-term rental properties across global OTA channels</li>
-                  <li>Building and maintaining live channel integrations with Booking.com, Airbnb, and Vrbo — real-time sync of availability, rates, and reservations</li>
+                  <li>Building features for a Django-based PMS serving thousands of short-term rental properties across global OTA channels</li>
+                  <li>Built and maintained live channel integrations with Booking.com, Airbnb, and Vrbo — real-time sync of availability, rates, and reservations</li>
+                  <li>Delivered promotions features connecting GuestReady to Airbnb, Vrbo, and Booking.com, enabling dynamic discount campaigns across OTA channels</li>
+                  <li>Implemented monitoring alarms in New Relic for proactive production observability and incident response</li>
+                  <li>Improved processing efficiency with a Redis hash-based deduplication layer that prevents reprocessing of stale events</li>
                   <li>Triaging production incidents with Sentry and Datadog; running zero-downtime bulk operations on large PostgreSQL tables</li>
-                  <li>Contributing to engineering standards through code reviews in a distributed team of 40+ engineers</li>
+                  <li>Maintaining engineering quality through code review in a distributed team of 40+ engineers</li>
+                  <li>Accelerating development workflows with AI coding tools (Claude Code, Cursor)</li>
                 </ul>
                 <div class="tag-row">
-                  <span>Django</span><span>PostgreSQL</span><span>Sentry</span><span>Datadog</span><span>REST APIs</span>
+                  <span>Django</span><span>PostgreSQL</span><span>Redis</span><span>Sentry</span><span>Datadog</span><span>New Relic</span><span>REST APIs</span>
                 </div>
               </div>
             </div>
@@ -222,13 +228,19 @@
             <div class="skill-group">
               <h3>Observability</h3>
               <div class="tag-row">
-                <span>Grafana</span><span>Sentry</span><span>Datadog</span><span>Telegraf</span>
+                <span>Grafana</span><span>Sentry</span><span>Datadog</span><span>New Relic</span><span>Telegraf</span>
               </div>
             </div>
             <div class="skill-group">
               <h3>Tooling</h3>
               <div class="tag-row">
                 <span>Git</span><span>Bash</span><span>Make</span><span>YAML</span>
+              </div>
+            </div>
+            <div class="skill-group">
+              <h3>AI Tooling</h3>
+              <div class="tag-row">
+                <span>Claude Code</span><span>Cursor</span>
               </div>
             </div>
           </div>
@@ -324,7 +336,7 @@
       <!-- Additional Info -->
       <section id="additional">
         <div class="container">
-          <h2 class="section-label">Publications</h2>
+          <h2 class="section-label">Additional</h2>
           <div class="additional-grid">
             <div>
               <h3 class="sub-label">Relevant Links</h3>
@@ -376,7 +388,7 @@
       <section id="contact">
         <div class="container">
           <h2 class="section-label">Contact</h2>
-          <p class="contact-intro">Open to backend engineering and technical lead roles. Based in Portugal, working remotely.</p>
+          <p class="contact-intro">Open to backend engineering and technical lead roles. Based in Portugal — fully remote, available immediately.</p>
           <div class="contact-grid">
             <div class="contact-info">
               <a href="mailto:julio.m.b.c.silva@gmail.com" class="contact-link">

--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
             <div class="skill-group">
               <h3>Languages</h3>
               <div class="tag-row">
-                <span class="primary">Python</span><span class="primary">Go</span><span>SQL</span>
+                <span class="primary">Python</span><span>Go</span><span class="primary">SQL</span>
               </div>
             </div>
             <div class="skill-group">
@@ -317,25 +317,25 @@
             <div class="skill-group">
               <h3>Infrastructure</h3>
               <div class="tag-row">
-                <span class="primary">Docker</span><span>Linux</span><span>AWS</span>
+                <span class="primary">Docker</span><span class="primary">Linux</span><span>AWS</span>
               </div>
             </div>
             <div class="skill-group">
               <h3>Observability</h3>
               <div class="tag-row">
-                <span>Grafana</span><span>Sentry</span><span>Datadog</span><span>New Relic</span><span>Telegraf</span>
+                <span>Grafana</span><span class="primary">Sentry</span><span>Datadog</span><span class="primary">New Relic</span><span>Telegraf</span>
               </div>
             </div>
             <div class="skill-group">
               <h3>Tooling</h3>
               <div class="tag-row">
-                <span>Git</span><span>Bash</span><span>Make</span><span>YAML</span>
+                <span class="primary">Git</span><span>Bash</span><span>Make</span><span>YAML</span>
               </div>
             </div>
             <div class="skill-group">
               <h3>AI Tooling</h3>
               <div class="tag-row">
-                <span>Claude Code</span><span>Cursor</span>
+                <span class="primary">Claude Code</span><span>Cursor</span>
               </div>
             </div>
           </div>

--- a/script.js
+++ b/script.js
@@ -1,24 +1,30 @@
 document.addEventListener('DOMContentLoaded', () => {
   const nav = document.getElementById('nav');
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-  // ── Theme ──────────────────────────────────────────────────────────────────
+  // ── Theme ────────────────────────────────────────────────────────────────
+  const themeToggle = document.querySelector('.theme-toggle');
+  const themeIcon = themeToggle.querySelector('use');
+
   function setTheme(theme) {
+    const dark = theme === 'dark';
     document.documentElement.setAttribute('data-theme', theme);
     localStorage.setItem('theme', theme);
-    document.getElementById('theme-icon').className =
-      theme === 'dark' ? 'fas fa-sun' : 'fas fa-moon';
+    themeIcon.setAttribute('href', dark ? '#i-sun' : '#i-moon');
+    themeToggle.setAttribute('aria-pressed', String(dark));
   }
 
-  // Sync icon with theme already set by the inline <head> script
+  // Sync the toggle with the theme already applied by the inline <head> script
   setTheme(localStorage.getItem('theme') || 'dark');
 
-  document.querySelector('.theme-toggle').addEventListener('click', () => {
+  themeToggle.addEventListener('click', () => {
     const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
     setTheme(isDark ? 'light' : 'dark');
   });
 
-  // ── Nav: scroll state & active link ───────────────────────────────────────
+  // ── Nav: scroll state & active link ────────────────────────────────────────
   const sections = [...document.querySelectorAll('section[id]')];
+  const navLinks = [...document.querySelectorAll('.nav-links a')];
 
   function updateNav() {
     nav.classList.toggle('scrolled', window.scrollY > 8);
@@ -29,25 +35,40 @@ document.addEventListener('DOMContentLoaded', () => {
       if (s.offsetTop <= mid) current = s.id;
     }
 
-    document.querySelectorAll('.nav-links a').forEach(a => {
+    for (const a of navLinks) {
       a.classList.toggle('active', a.getAttribute('href') === `#${current}`);
-    });
+    }
   }
 
-  window.addEventListener('scroll', updateNav, { passive: true });
+  // Throttle to one run per animation frame
+  let ticking = false;
+  window.addEventListener(
+    'scroll',
+    () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        updateNav();
+        ticking = false;
+      });
+    },
+    { passive: true }
+  );
   updateNav();
 
-  // ── Mobile menu ────────────────────────────────────────────────────────────
-  document.querySelector('.nav-toggle').addEventListener('click', () => {
-    const open = nav.classList.toggle('menu-open');
-    document.body.style.overflow = open ? 'hidden' : '';
-  });
+  // ── Mobile menu ──────────────────────────────────────────────────────────
+  const navToggle = document.querySelector('.nav-toggle');
 
-  document.querySelectorAll('.nav-links a').forEach(a => {
-    a.addEventListener('click', () => {
-      nav.classList.remove('menu-open');
-      document.body.style.overflow = '';
-    });
+  function closeMenu() {
+    nav.classList.remove('menu-open');
+    navToggle.setAttribute('aria-expanded', 'false');
+    document.body.style.overflow = '';
+  }
+
+  navToggle.addEventListener('click', () => {
+    const open = nav.classList.toggle('menu-open');
+    navToggle.setAttribute('aria-expanded', String(open));
+    document.body.style.overflow = open ? 'hidden' : '';
   });
 
   // ── Smooth scroll ──────────────────────────────────────────────────────────
@@ -58,50 +79,58 @@ document.addEventListener('DOMContentLoaded', () => {
       const target = document.querySelector(id);
       if (!target) return;
       e.preventDefault();
-      window.scrollTo({ top: target.offsetTop - 64, behavior: 'smooth' });
+      closeMenu();
+      window.scrollTo({
+        top: target.offsetTop - 64,
+        behavior: prefersReducedMotion ? 'auto' : 'smooth',
+      });
     });
   });
 
   // ── Scroll reveal ──────────────────────────────────────────────────────────
-  const revealTargets = document.querySelectorAll([
-    '#about .section-label',
-    '#about .about-grid',
-    '#experience .section-label',
-    '.timeline-item',
-    '#skills .section-label',
-    '.skill-group',
-    '#projects .section-label',
-    '.project-card',
-    '#additional .section-label',
-    '#additional .additional-grid',
-    '#contact .section-label',
-    '#contact .contact-intro',
-    '#contact .contact-grid',
-  ].join(', '));
+  const revealTargets = document.querySelectorAll(
+    [
+      '#about .section-label',
+      '#about .about-grid',
+      '#experience .section-label',
+      '.timeline-item',
+      '#skills .section-label',
+      '#skills .section-note',
+      '.skill-group',
+      '#projects .section-label',
+      '.project-card',
+      '#additional .section-label',
+      '#additional .additional-grid',
+      '#contact .section-label',
+      '#contact .contact-intro',
+      '#contact .contact-grid',
+    ].join(', ')
+  );
 
   revealTargets.forEach(el => el.classList.add('reveal'));
 
   const revealObserver = new IntersectionObserver(
-    entries => entries.forEach(e => {
-      if (e.isIntersecting) {
-        e.target.classList.add('visible');
-        revealObserver.unobserve(e.target);
-      }
-    }),
+    entries =>
+      entries.forEach(e => {
+        if (e.isIntersecting) {
+          e.target.classList.add('visible');
+          revealObserver.unobserve(e.target);
+        }
+      }),
     { threshold: 0.1, rootMargin: '0px 0px -32px 0px' }
   );
 
   revealTargets.forEach(el => revealObserver.observe(el));
 
   // ── Contact form ───────────────────────────────────────────────────────────
-  const form      = document.getElementById('contact-form');
+  const form = document.getElementById('contact-form');
   const submitBtn = document.getElementById('submit-btn');
-  const btnText   = submitBtn.querySelector('.btn-text');
+  const btnText = submitBtn.querySelector('.btn-text');
 
   form.addEventListener('submit', async e => {
     e.preventDefault();
     submitBtn.disabled = true;
-    btnText.textContent = 'Sending...';
+    btnText.textContent = 'sending...';
 
     try {
       const res = await Promise.race([
@@ -115,16 +144,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
       if (!res.ok) throw new Error('error');
       submitBtn.classList.add('success');
-      btnText.textContent = 'Sent!';
+      btnText.textContent = 'sent!';
       form.reset();
     } catch {
       submitBtn.classList.add('error');
-      btnText.textContent = 'Failed';
+      btnText.textContent = 'failed';
     } finally {
       setTimeout(() => {
         submitBtn.disabled = false;
         submitBtn.classList.remove('success', 'error');
-        btnText.textContent = 'Send message';
+        btnText.textContent = 'send message';
       }, 3000);
     }
   });

--- a/styles.css
+++ b/styles.css
@@ -2,29 +2,68 @@
    Design Tokens
    ============================================================================= */
 :root {
-  --c-bg:         #ffffff;
-  --c-bg-alt:     #f8fafc;
-  --c-border:     #e2e8f0;
-  --c-text:       #0f172a;
-  --c-muted:      #64748b;
-  --c-accent:     #2563eb;
-  --c-accent-h:   #1d4ed8;
+  /* Color — light */
+  --c-bg:            #ffffff;
+  --c-surface:       #f7f7f8;
+  --c-surface-2:     #f0f0f2;
+  --c-border:        #e4e4e7;
+  --c-border-strong: #d4d4d8;
+  --c-text:          #14141a;
+  --c-muted:         #5c5c66;
+  --c-faint:         #9a9aa4;
+  --c-accent:        #2563eb;
+  --c-accent-h:      #1d4ed8;
+  --c-accent-dim:    rgba(37, 99, 235, 0.09);
+  --c-on-accent:     #ffffff;
+  --grid:            rgba(0, 0, 0, 0.028);
+  --shadow:          0 1px 2px rgba(0, 0, 0, 0.06), 0 10px 28px rgba(0, 0, 0, 0.08);
 
-  --nav-h:        64px;
-  --max-w:        860px;
-  --r:            6px;
-  --ease:         cubic-bezier(0.4, 0, 0.2, 1);
-  --dur:          150ms;
+  /* Typography */
+  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --fs-xs:   12px;
+  --fs-sm:   13px;
+  --fs-base: 14px;
+  --fs-md:   15px;
+  --fs-lg:   18px;
+  --fs-xl:   20px;
+
+  /* Spacing scale */
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 24px;
+  --sp-6: 32px;
+  --sp-7: 48px;
+  --sp-8: 64px;
+  --sp-9: 96px;
+
+  /* Geometry & motion */
+  --nav-h: 64px;
+  --max-w: 900px;
+  --r:     8px;
+  --r-sm:  4px;
+  --ease:  cubic-bezier(0.4, 0, 0.2, 1);
+  --dur:   160ms;
+  --lift:  -3px;
 }
 
 [data-theme="dark"] {
-  --c-bg:         #0c0c0c;
-  --c-bg-alt:     #161616;
-  --c-border:     #3a3a3a;
-  --c-text:       #f1f5f9;
-  --c-muted:      #a1a1aa;
-  --c-accent:     #3b82f6;
-  --c-accent-h:   #60a5fa;
+  --c-bg:            #0a0a0b;
+  --c-surface:       #101013;
+  --c-surface-2:     #17171b;
+  --c-border:        #232328;
+  --c-border-strong: #36363d;
+  --c-text:          #e7e7ea;
+  --c-muted:         #8b8b95;
+  --c-faint:         #54545d;
+  --c-accent:        #58a6ff;
+  --c-accent-h:      #79b8ff;
+  --c-accent-dim:    rgba(88, 166, 255, 0.13);
+  --c-on-accent:     #07080b;
+  --grid:            rgba(255, 255, 255, 0.022);
+  --shadow:          0 1px 2px rgba(0, 0, 0, 0.4), 0 12px 32px rgba(0, 0, 0, 0.45);
 }
 
 /* =============================================================================
@@ -38,23 +77,86 @@
 
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: calc(var(--nav-h) + var(--sp-4));
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
 
 body {
-  font-family: 'Inter', system-ui, -apple-system, sans-serif;
-  font-size: 15px;
+  position: relative;
+  font-family: var(--font-sans);
+  font-size: var(--fs-md);
   line-height: 1.7;
   background: var(--c-bg);
   color: var(--c-text);
-  transition: background 200ms var(--ease), color 200ms var(--ease);
+  transition: background 250ms var(--ease), color 250ms var(--ease);
+  overflow-x: hidden;
+}
+
+/* Faint technical grid, fading out below the fold */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image:
+    linear-gradient(var(--grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+  background-size: 48px 48px;
+  -webkit-mask-image: radial-gradient(ellipse 90% 55% at 50% 0%, #000 0%, transparent 78%);
+          mask-image: radial-gradient(ellipse 90% 55% at 50% 0%, #000 0%, transparent 78%);
 }
 
 img    { display: block; max-width: 100%; }
 a      { color: inherit; text-decoration: none; }
 ul     { list-style: none; }
 button { font-family: inherit; }
+
+h1, h2, h3 { font-family: var(--font-mono); font-weight: 500; }
+
+.icon {
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  vertical-align: middle;
+  fill: currentColor;
+  flex-shrink: 0;
+}
+.sprite { position: absolute; width: 0; height: 0; overflow: hidden; }
+
+/* Accessibility helpers */
+.sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link {
+  position: fixed;
+  top: var(--sp-2);
+  left: var(--sp-2);
+  z-index: 200;
+  transform: translateY(-160%);
+  background: var(--c-accent);
+  color: var(--c-on-accent);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  transition: transform var(--dur) var(--ease);
+}
+.skip-link:focus { transform: none; }
+
+:focus-visible {
+  outline: 2px solid var(--c-accent);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
 
 /* =============================================================================
    Layout
@@ -63,16 +165,13 @@ button { font-family: inherit; }
   width: 100%;
   max-width: var(--max-w);
   margin: 0 auto;
-  padding: 0 24px;
+  padding: 0 var(--sp-5);
 }
 
-section {
-  padding: 96px 0;
-}
+section { padding: var(--sp-9) 0; }
+section[id] { scroll-margin-top: var(--nav-h); }
 
-#hero {
-  padding-top: calc(var(--nav-h) + 96px);
-}
+#hero { padding-top: calc(var(--nav-h) + var(--sp-9)); }
 
 /* =============================================================================
    Navigation
@@ -83,74 +182,73 @@ section {
   z-index: 100;
   height: var(--nav-h);
   border-bottom: 1px solid transparent;
-  transition:
-    background var(--dur) var(--ease),
-    border-color var(--dur) var(--ease);
+  transition: background var(--dur) var(--ease), border-color var(--dur) var(--ease);
 }
 
 #nav.scrolled,
 #nav.menu-open {
   background: var(--c-bg);
+  background: color-mix(in srgb, var(--c-bg) 82%, transparent);
+  -webkit-backdrop-filter: blur(12px);
+          backdrop-filter: blur(12px);
   border-bottom-color: var(--c-border);
 }
 
 .nav-inner {
   display: flex;
   align-items: center;
-  gap: 32px;
+  gap: var(--sp-6);
   height: 100%;
   max-width: var(--max-w);
   margin: 0 auto;
-  padding: 0 24px;
+  padding: 0 var(--sp-5);
 }
 
 .nav-logo {
-  font-size: 14px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-family: var(--font-mono);
+  font-size: var(--fs-base);
+  font-weight: 700;
+  letter-spacing: -0.02em;
   color: var(--c-text);
   margin-right: auto;
   transition: opacity var(--dur);
 }
-.nav-logo:hover { opacity: 0.65; }
+.nav-logo .accent { color: var(--c-accent); }
+.nav-logo:hover { opacity: 0.7; }
 
-.nav-links {
-  display: flex;
-  gap: 28px;
-}
+.nav-links { display: flex; gap: var(--sp-5); }
 .nav-links a {
-  font-size: 14px;
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
   color: var(--c-muted);
   transition: color var(--dur);
 }
-.nav-links a:hover,
-.nav-links a.active { color: var(--c-text); }
+.nav-links a:hover { color: var(--c-text); }
+.nav-links a.active { color: var(--c-accent); }
 
-.nav-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
+.nav-actions { display: flex; align-items: center; gap: var(--sp-2); }
 
 .theme-toggle,
 .nav-toggle {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 38px;
+  height: 38px;
   background: transparent;
   border: 1px solid var(--c-border);
-  border-radius: var(--r);
+  border-radius: var(--r-sm);
   color: var(--c-muted);
   cursor: pointer;
-  transition: color var(--dur), border-color var(--dur);
+  transition: color var(--dur), border-color var(--dur), background var(--dur);
 }
 .theme-toggle:hover,
 .nav-toggle:hover {
   color: var(--c-text);
-  border-color: var(--c-muted);
+  border-color: var(--c-border-strong);
+  background: var(--c-surface);
 }
+.theme-toggle .icon { width: 17px; height: 17px; }
 
 .nav-toggle {
   display: none;
@@ -164,178 +262,223 @@ section {
   background: currentColor;
   border-radius: 2px;
   transform-origin: center;
-  transition: transform 200ms var(--ease), opacity 200ms;
+  transition: transform 220ms var(--ease), opacity 220ms;
 }
-
-#nav.menu-open .nav-toggle span:nth-child(1) { transform: translateY(6.5px) rotate(45deg);  }
+#nav.menu-open .nav-toggle span:nth-child(1) { transform: translateY(6.5px) rotate(45deg); }
 #nav.menu-open .nav-toggle span:nth-child(2) { opacity: 0; transform: scaleX(0); }
 #nav.menu-open .nav-toggle span:nth-child(3) { transform: translateY(-6.5px) rotate(-45deg); }
 
 /* =============================================================================
-   Section Label
+   Section Label  ( [02] experience ─────────── )
    ============================================================================= */
 .section-label {
-  font-size: 18px;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  font-family: var(--font-mono);
+  font-size: var(--fs-lg);
+  font-weight: 500;
   color: var(--c-text);
-  margin-bottom: 48px;
+  margin-bottom: var(--sp-7);
 }
+.section-label .idx {
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  color: var(--c-accent);
+}
+.section-label::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--c-border);
+}
+.section-label:has(+ .section-note) { margin-bottom: var(--sp-3); }
+
+.section-note {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--c-muted);
+  margin-bottom: var(--sp-7);
+}
+.section-note .primary-marker { color: var(--c-accent); }
 
 /* =============================================================================
    Hero
    ============================================================================= */
-#hero .container { max-width: 720px; }
+#hero .container { max-width: 760px; }
 
 .hero-label {
-  font-size: 13px;
-  font-weight: 500;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  color: var(--c-accent);
-  margin-bottom: 20px;
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  letter-spacing: 0.02em;
+  color: var(--c-muted);
+  margin-bottom: var(--sp-5);
   animation: fadeUp 500ms var(--ease) both;
+}
+.caret {
+  display: inline-block;
+  width: 0.55ch;
+  height: 1.05em;
+  margin-left: 4px;
+  background: var(--c-accent);
+  vertical-align: -0.16em;
+  animation: blink 1.1s steps(1) infinite;
 }
 
 #hero h1 {
-  font-size: clamp(2.8rem, 7vw, 4.5rem);
-  font-weight: 600;
+  font-family: var(--font-mono);
+  font-size: clamp(2.6rem, 7vw, 4.2rem);
+  font-weight: 700;
   letter-spacing: -0.04em;
-  line-height: 1.0;
-  margin-bottom: 24px;
+  line-height: 1.02;
+  margin-bottom: var(--sp-5);
   animation: fadeUp 500ms var(--ease) 80ms both;
 }
 
 .hero-desc {
-  font-size: 17px;
+  font-size: var(--fs-lg);
   line-height: 1.6;
   color: var(--c-muted);
-  max-width: 520px;
-  margin-bottom: 36px;
+  max-width: 560px;
+  margin-bottom: var(--sp-7);
   animation: fadeUp 500ms var(--ease) 160ms both;
 }
 
 .hero-cta {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
-  margin-bottom: 40px;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-7);
   animation: fadeUp 500ms var(--ease) 240ms both;
 }
 
 .hero-socials {
   display: flex;
-  gap: 18px;
+  gap: var(--sp-5);
   animation: fadeUp 500ms var(--ease) 320ms both;
 }
 .hero-socials a {
-  font-size: 19px;
+  display: inline-flex;
   color: var(--c-muted);
-  transition: color var(--dur);
+  transition: color var(--dur), transform var(--dur);
 }
-.hero-socials a:hover { color: var(--c-text); }
+.hero-socials a:hover { color: var(--c-text); transform: translateY(-2px); }
+.hero-socials .icon { width: 21px; height: 21px; }
 
 @keyframes fadeUp {
-  from { opacity: 0; transform: translateY(18px); }
+  from { opacity: 0; transform: translateY(16px); }
   to   { opacity: 1; transform: none; }
+}
+@keyframes blink {
+  0%, 50%     { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
 }
 
 /* Buttons */
 .btn {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 9px 18px;
-  border-radius: var(--r);
-  font-size: 14px;
+  gap: var(--sp-2);
+  padding: 10px 18px;
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
   font-weight: 500;
   cursor: pointer;
   white-space: nowrap;
   border: 1px solid transparent;
-  transition:
-    background var(--dur),
-    border-color var(--dur),
-    color var(--dur),
-    opacity var(--dur);
+  transition: background var(--dur), border-color var(--dur), color var(--dur),
+    transform var(--dur), box-shadow var(--dur);
+}
+.btn:active { transform: translateY(0); }
+
+.btn-primary { background: var(--c-accent); color: var(--c-on-accent); }
+.btn-primary:hover {
+  background: var(--c-accent-h);
+  transform: translateY(var(--lift));
+  box-shadow: var(--shadow);
 }
 
-.btn-primary {
-  background: var(--c-accent);
-  color: #fff;
-}
-.btn-primary:hover { background: var(--c-accent-h); }
-
-.btn-outline {
+.btn-ghost {
   background: transparent;
-  border-color: var(--c-border);
+  border-color: var(--c-border-strong);
   color: var(--c-text);
 }
-.btn-outline:hover { border-color: var(--c-muted); }
+.btn-ghost:hover { border-color: var(--c-accent); color: var(--c-accent); }
+.btn-ghost .arrow { transition: transform var(--dur); }
+.btn-ghost:hover .arrow { transform: translateX(3px); }
 
 /* =============================================================================
    About
    ============================================================================= */
 .about-grid {
   display: grid;
-  grid-template-columns: 260px 1fr;
-  gap: 48px;
+  grid-template-columns: 240px 1fr;
+  gap: var(--sp-7);
   align-items: start;
 }
 
+.about-photo { position: relative; width: max-content; }
 .about-photo img {
-  width: 260px;
-  height: 260px;
+  width: 240px;
+  height: 300px;
   object-fit: cover;
   border-radius: var(--r);
   border: 1px solid var(--c-border);
 }
+.photo-caption {
+  display: block;
+  margin-top: var(--sp-2);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--c-faint);
+}
 
 .about-text p {
   color: var(--c-muted);
-  margin-bottom: 16px;
-  font-size: 15px;
+  margin-bottom: var(--sp-4);
 }
 .about-text p:last-of-type { margin-bottom: 0; }
 
 .about-details {
-  margin-top: 28px;
-  padding-top: 28px;
+  margin-top: var(--sp-6);
+  padding-top: var(--sp-6);
   border-top: 1px solid var(--c-border);
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  font-size: 14px;
-  color: var(--c-muted);
+  gap: var(--sp-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
 }
-
-.detail-label {
-  display: inline-block;
-  min-width: 82px;
-  font-weight: 500;
-  color: var(--c-text);
-  margin-right: 8px;
+.about-details > div { display: flex; gap: var(--sp-4); }
+.about-details dt {
+  flex: 0 0 84px;
+  color: var(--c-accent);
 }
+.about-details dd { color: var(--c-muted); }
 
 /* =============================================================================
    Timeline
    ============================================================================= */
 .timeline {
   position: relative;
-  padding-left: 20px;
+  padding-left: var(--sp-5);
   border-left: 1px solid var(--c-border);
 }
 
 .timeline-item {
   position: relative;
-  padding: 0 0 56px 36px;
+  padding: 0 0 var(--sp-8) var(--sp-6);
 }
 .timeline-item:last-child { padding-bottom: 0; }
 
 .timeline-item::before {
   content: '';
   position: absolute;
-  top: 7px;
+  top: 6px;
   left: -4px;
   width: 7px;
   height: 7px;
@@ -348,100 +491,78 @@ section {
 .timeline-meta {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 12px;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-3);
 }
-
 .timeline-period {
-  font-size: 13px;
-  font-weight: 500;
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
   color: var(--c-muted);
-}
-
-.timeline-loc {
-  font-size: 12px;
-  color: var(--c-muted);
-  padding: 2px 9px;
-  border: 1px solid var(--c-border);
-  border-radius: 100px;
 }
 
 .timeline-body h3 {
-  font-size: 16px;
-  font-weight: 600;
-  margin-bottom: 4px;
+  font-size: var(--fs-md);
+  font-weight: 500;
+  margin-bottom: var(--sp-1);
 }
-
 .timeline-org {
-  font-size: 14px;
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
   color: var(--c-accent);
-  margin-bottom: 14px;
+  margin-bottom: var(--sp-4);
 }
 
 .timeline-body ul {
   display: flex;
   flex-direction: column;
-  gap: 7px;
-  margin-bottom: 16px;
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-4);
 }
-
 .timeline-body li {
-  font-size: 14px;
-  color: var(--c-muted);
-  padding-left: 14px;
   position: relative;
+  padding-left: var(--sp-4);
+  font-size: var(--fs-base);
+  color: var(--c-muted);
 }
 .timeline-body li::before {
-  content: '';
+  content: '›';
   position: absolute;
   left: 0;
-  top: 11px;
-  width: 5px;
-  height: 1px;
-  background: var(--c-muted);
-  opacity: 0.5;
+  top: -1px;
+  font-family: var(--font-mono);
+  color: var(--c-accent);
 }
 
 .timeline-note {
-  font-size: 14px;
+  font-size: var(--fs-base);
   color: var(--c-muted);
-  margin-bottom: 12px;
+  margin-bottom: var(--sp-3);
 }
+.timeline-note strong { color: var(--c-text); font-weight: 500; }
 
 /* =============================================================================
-   Tag Row — shared component
+   Chips — tags, location & language badges (shared)
    ============================================================================= */
-.tag-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
+.tag-row { display: flex; flex-wrap: wrap; gap: var(--sp-2); }
 
-.tag-row span {
-  font-size: 12px;
-  padding: 3px 9px;
+.tag-row span,
+.timeline-loc,
+.lang-badge {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  padding: 3px 8px;
   border: 1px solid var(--c-border);
-  border-radius: 100px;
+  border-radius: var(--r-sm);
+  background: var(--c-surface);
   color: var(--c-muted);
+  white-space: nowrap;
   transition: border-color var(--dur), color var(--dur);
 }
 
-/* =============================================================================
-   Skills
-   ============================================================================= */
-.skills-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
-  gap: 36px;
-}
-
-.skill-group h3 {
-  font-size: 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--c-muted);
-  margin-bottom: 12px;
+.tag-row span.primary {
+  border-color: var(--c-accent);
+  background: var(--c-accent-dim);
+  color: var(--c-accent);
 }
 
 .skill-group .tag-row span:hover {
@@ -450,50 +571,75 @@ section {
 }
 
 /* =============================================================================
+   Skills
+   ============================================================================= */
+.skills-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--sp-6) var(--sp-5);
+}
+.skill-group h3 {
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--c-muted);
+  margin-bottom: var(--sp-3);
+}
+
+/* =============================================================================
    Projects
    ============================================================================= */
 .projects-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 16px;
+  gap: var(--sp-4);
 }
 
 .project-card {
-  padding: 24px;
+  position: relative;
+  padding: var(--sp-5);
   border: 1px solid var(--c-border);
   border-radius: var(--r);
-  transition: border-color var(--dur);
+  background: var(--c-surface);
+  transition: border-color var(--dur), transform var(--dur), box-shadow var(--dur);
 }
-.project-card:hover { border-color: var(--c-muted); }
+.project-card:hover {
+  border-color: var(--c-border-strong);
+  transform: translateY(var(--lift));
+  box-shadow: var(--shadow);
+}
 
 .project-top {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  margin-bottom: 10px;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-3);
 }
 .project-top h3 {
-  font-size: 15px;
-  font-weight: 600;
-}
-
-.project-links {
   display: flex;
-  gap: 12px;
-  flex-shrink: 0;
+  align-items: baseline;
+  gap: var(--sp-2);
+  font-size: var(--fs-md);
+  font-weight: 500;
 }
+.card-idx { font-size: var(--fs-xs); color: var(--c-faint); }
+
+.project-links { display: flex; gap: var(--sp-3); flex-shrink: 0; }
 .project-links a {
-  font-size: 15px;
+  display: inline-flex;
   color: var(--c-muted);
-  transition: color var(--dur);
+  transition: color var(--dur), transform var(--dur);
 }
-.project-links a:hover { color: var(--c-text); }
+.project-links a:hover { color: var(--c-accent); transform: translateY(-2px); }
+.project-links .icon { width: 18px; height: 18px; }
 
 .project-card > p {
-  font-size: 14px;
+  font-size: var(--fs-base);
   color: var(--c-muted);
   line-height: 1.6;
-  margin-bottom: 16px;
+  margin-bottom: var(--sp-4);
 }
 
 /* =============================================================================
@@ -502,139 +648,121 @@ section {
 .additional-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 48px;
+  gap: var(--sp-7);
 }
-
 .sub-label {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--fs-xs);
+  font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   color: var(--c-muted);
-  margin-bottom: 20px;
+  margin-bottom: var(--sp-5);
 }
 
-.link-list {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
+.link-list { display: flex; flex-direction: column; gap: var(--sp-3); }
 .link-list a {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  font-size: 14px;
+  gap: var(--sp-2);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
   color: var(--c-muted);
   transition: color var(--dur);
 }
 .link-list a:hover { color: var(--c-accent); }
-.link-list a i { font-size: 11px; }
+.link-list .icon { width: 13px; height: 13px; color: var(--c-faint); }
+.link-list a:hover .icon { color: var(--c-accent); }
 
-.lang-list {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
+.lang-list { display: flex; flex-direction: column; }
 .lang-list li {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 14px;
+  gap: var(--sp-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  padding: var(--sp-3) 0;
+  border-bottom: 1px solid var(--c-border);
 }
-.lang-badge {
-  font-size: 12px;
-  padding: 2px 9px;
-  border: 1px solid var(--c-border);
-  border-radius: 100px;
-  color: var(--c-muted);
-}
+.lang-list li:last-child { border-bottom: 0; }
 
 /* =============================================================================
    Contact
    ============================================================================= */
 .contact-intro {
-  font-size: 16px;
+  font-size: var(--fs-lg);
   color: var(--c-muted);
-  margin-bottom: 40px;
+  margin-bottom: var(--sp-7);
+  max-width: 620px;
 }
 
 .contact-grid {
   display: grid;
-  grid-template-columns: 260px 1fr;
-  gap: 48px;
+  grid-template-columns: 280px 1fr;
+  gap: var(--sp-7);
   align-items: start;
 }
 
-.contact-info {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-}
-
+.contact-info { display: flex; flex-direction: column; gap: var(--sp-4); }
 .contact-link {
   display: flex;
   align-items: center;
-  gap: 12px;
-  font-size: 14px;
+  gap: var(--sp-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
   color: var(--c-muted);
   transition: color var(--dur);
+  word-break: break-word;
 }
 .contact-link:hover { color: var(--c-text); }
-.contact-link i {
-  width: 16px;
-  text-align: center;
-}
+.contact-link .icon { width: 16px; height: 16px; color: var(--c-accent); }
 
-#contact-form {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.form-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
-}
+#contact-form { display: flex; flex-direction: column; gap: var(--sp-3); }
+.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-3); }
 
 #contact-form input,
 #contact-form textarea {
   width: 100%;
-  padding: 10px 13px;
-  background: var(--c-bg-alt);
+  padding: 11px 13px;
+  background: var(--c-surface);
   border: 1px solid var(--c-border);
-  border-radius: var(--r);
+  border-radius: var(--r-sm);
   color: var(--c-text);
-  font-family: inherit;
-  font-size: 14px;
+  font-family: var(--font-mono);
+  font-size: var(--fs-base);
   outline: none;
-  resize: none;
-  transition: border-color var(--dur);
+  resize: vertical;
+  transition: border-color var(--dur), box-shadow var(--dur);
   -webkit-appearance: none;
 }
 #contact-form input:focus,
-#contact-form textarea:focus { border-color: var(--c-accent); }
-
-#contact-form input::placeholder,
-#contact-form textarea::placeholder {
-  color: var(--c-muted);
-  opacity: 0.5;
+#contact-form textarea:focus {
+  border-color: var(--c-accent);
+  box-shadow: 0 0 0 3px var(--c-accent-dim);
 }
+#contact-form input::placeholder,
+#contact-form textarea::placeholder { color: var(--c-faint); }
 
 #submit-btn {
   align-self: flex-start;
-  padding: 10px 22px;
+  padding: 11px 22px;
   background: var(--c-accent);
-  color: #fff;
+  color: var(--c-on-accent);
   border: none;
-  border-radius: var(--r);
-  font-size: 14px;
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: background var(--dur), opacity var(--dur);
+  transition: background var(--dur), transform var(--dur), box-shadow var(--dur), opacity var(--dur);
 }
-#submit-btn:hover    { background: var(--c-accent-h); }
-#submit-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+#submit-btn:hover {
+  background: var(--c-accent-h);
+  transform: translateY(var(--lift));
+  box-shadow: var(--shadow);
+}
+#submit-btn:active   { transform: translateY(0); }
+#submit-btn:disabled { opacity: 0.55; cursor: not-allowed; transform: none; box-shadow: none; }
 #submit-btn.success  { background: #16a34a; }
 #submit-btn.error    { background: #dc2626; }
 
@@ -642,45 +770,56 @@ section {
    Footer
    ============================================================================= */
 footer {
-  padding: 32px 0;
+  padding: var(--sp-6) 0;
   border-top: 1px solid var(--c-border);
 }
-
 .footer-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: var(--sp-4);
+  flex-wrap: wrap;
 }
-
-.footer-name {
-  font-size: 13px;
+.footer-name,
+.footer-built {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
   color: var(--c-muted);
 }
+.footer-built { color: var(--c-faint); }
 
-.footer-socials {
-  display: flex;
-  gap: 16px;
-}
+.footer-socials { display: flex; gap: var(--sp-4); }
 .footer-socials a {
-  font-size: 16px;
+  display: inline-flex;
   color: var(--c-muted);
-  transition: color var(--dur);
+  transition: color var(--dur), transform var(--dur);
 }
-.footer-socials a:hover { color: var(--c-text); }
+.footer-socials a:hover { color: var(--c-text); transform: translateY(-2px); }
+.footer-socials .icon { width: 18px; height: 18px; }
 
 /* =============================================================================
-   Scroll Reveal
+   Scroll Reveal + stagger
    ============================================================================= */
 .reveal {
   opacity: 0;
-  transform: translateY(20px);
-  transition: opacity 500ms var(--ease), transform 500ms var(--ease);
+  transform: translateY(16px);
+  transition: opacity 600ms var(--ease), transform 600ms var(--ease);
 }
+.reveal.visible { opacity: 1; transform: none; }
 
-.reveal.visible {
-  opacity: 1;
-  transform: none;
-}
+.timeline-item:nth-child(2) { transition-delay: 70ms; }
+.timeline-item:nth-child(3) { transition-delay: 140ms; }
+.skill-group:nth-child(2),
+.project-card:nth-child(2) { transition-delay: 60ms; }
+.skill-group:nth-child(3),
+.project-card:nth-child(3) { transition-delay: 120ms; }
+.skill-group:nth-child(4),
+.project-card:nth-child(4) { transition-delay: 180ms; }
+.skill-group:nth-child(5),
+.project-card:nth-child(5) { transition-delay: 240ms; }
+.skill-group:nth-child(6) { transition-delay: 300ms; }
+.skill-group:nth-child(7) { transition-delay: 360ms; }
+.skill-group:nth-child(8) { transition-delay: 420ms; }
 
 /* =============================================================================
    Responsive
@@ -688,78 +827,75 @@ footer {
 @media (max-width: 680px) {
   .nav-toggle { display: flex; }
 
-  /* Fullscreen overlay */
   .nav-links {
-    display: flex;
     position: fixed;
     inset: var(--nav-h) 0 0 0;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 8px;
+    gap: var(--sp-2);
     background: var(--c-bg);
     opacity: 0;
     pointer-events: none;
     transition: opacity 300ms var(--ease);
     z-index: 99;
   }
-
   .nav-links li {
-    transform: translateY(16px);
     opacity: 0;
-    transition:
-      transform 350ms var(--ease),
-      opacity 350ms var(--ease);
+    transform: translateY(16px);
+    transition: transform 350ms var(--ease), opacity 350ms var(--ease);
   }
-
   .nav-links a {
-    font-size: 26px;
-    font-weight: 600;
-    letter-spacing: -0.02em;
-    color: var(--c-muted);
-    padding: 12px 24px;
+    font-size: var(--fs-xl);
+    padding: var(--sp-3) var(--sp-5);
     display: block;
-    transition: color var(--dur);
   }
-  .nav-links a:hover,
-  .nav-links a.active { color: var(--c-text); }
-
-  #nav.menu-open .nav-links {
-    opacity: 1;
-    pointer-events: auto;
-  }
-
-  #nav.menu-open .nav-links li {
-    opacity: 1;
-    transform: none;
-  }
-
-  /* Stagger link entrance */
-  #nav.menu-open .nav-links li:nth-child(1) { transition-delay: 60ms;  }
+  #nav.menu-open .nav-links { opacity: 1; pointer-events: auto; }
+  #nav.menu-open .nav-links li { opacity: 1; transform: none; }
+  #nav.menu-open .nav-links li:nth-child(1) { transition-delay: 60ms; }
   #nav.menu-open .nav-links li:nth-child(2) { transition-delay: 120ms; }
   #nav.menu-open .nav-links li:nth-child(3) { transition-delay: 180ms; }
   #nav.menu-open .nav-links li:nth-child(4) { transition-delay: 240ms; }
   #nav.menu-open .nav-links li:nth-child(5) { transition-delay: 300ms; }
 
-  section { padding: 72px 0; }
-  #hero   { padding-top: calc(var(--nav-h) + 72px); }
+  section { padding: var(--sp-8) 0; }
+  #hero   { padding-top: calc(var(--nav-h) + var(--sp-7)); }
 
-  .about-grid {
-    grid-template-columns: 1fr;
-    gap: 28px;
-  }
-  .about-photo { display: block; }
-  .about-photo img { width: 160px; height: 160px; margin-left: 0; margin-right: auto; }
+  .hero-desc { font-size: var(--fs-md); }
+
+  .about-grid { grid-template-columns: 1fr; gap: var(--sp-6); }
+  .about-photo img { width: 168px; height: 210px; }
+
+  .timeline { padding-left: var(--sp-4); }
+  .timeline-item { padding-left: var(--sp-5); padding-bottom: var(--sp-7); }
+  .timeline-meta { flex-wrap: wrap; gap: var(--sp-2); }
 
   .projects-grid   { grid-template-columns: 1fr; }
-  .additional-grid { grid-template-columns: 1fr; gap: 36px; }
+  .additional-grid { grid-template-columns: 1fr; gap: var(--sp-6); }
 
-  .contact-grid { grid-template-columns: 1fr; gap: 32px; }
+  .contact-grid { grid-template-columns: 1fr; gap: var(--sp-6); }
   .form-row     { grid-template-columns: 1fr; }
+
+  .footer-inner { justify-content: center; text-align: center; }
+  .footer-built { order: 3; flex-basis: 100%; text-align: center; }
 }
 
 @media (max-width: 400px) {
-  .container { padding: 0 16px; }
-  section    { padding: 56px 0; }
-  #hero h1   { font-size: 2.4rem; }
+  .container { padding: 0 var(--sp-4); }
+  section    { padding: var(--sp-7) 0; }
+}
+
+/* =============================================================================
+   Reduced motion
+   ============================================================================= */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+  html { scroll-behavior: auto; }
+  .reveal { opacity: 1; transform: none; }
+  .caret { opacity: 1; }
 }

--- a/styles.css
+++ b/styles.css
@@ -186,12 +186,21 @@ section[id] { scroll-margin-top: var(--nav-h); }
 }
 
 #nav.scrolled,
-#nav.menu-open {
+#nav.menu-open { border-bottom-color: var(--c-border); }
+
+/* Blur lives on a ::before layer, NOT on #nav itself — putting backdrop-filter
+   on #nav would make it the containing block for the fixed .nav-links overlay
+   and collapse the mobile menu. */
+#nav.scrolled::before,
+#nav.menu-open::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
   background: var(--c-bg);
   background: color-mix(in srgb, var(--c-bg) 82%, transparent);
   -webkit-backdrop-filter: blur(12px);
           backdrop-filter: blur(12px);
-  border-bottom-color: var(--c-border);
 }
 
 .nav-inner {


### PR DESCRIPTION
## Summary

Substantial redesign of the single-page portfolio toward a **technical/terminal aesthetic**, plus content, SEO, accessibility, and performance improvements. Stays vanilla HTML/CSS/JS — no frameworks, no build step.

## Changes

**Design & UX**
- Mono-dominant typography (JetBrains Mono) with Inter for prose; dark-first monochrome palette + single blue accent + faint technical grid
- Terminal detailing: prompt-style hero label with blinking caret, indexed section headers (`01 — about`), key/value about block, code-token style tags
- Hover lift + shadow on cards/buttons, staggered scroll reveals
- Spacing + type scales replace ~40 hardcoded values; deduped chip styles

**Content** (truthful — no fabricated metrics)
- Experience corrected to **six years**; sharpened hero/about copy
- Added **AWS** to skills; highlighted core stack
- Dropped "available immediately" and the technical-leadership-track line

**Accessibility**
- Global `:focus-visible`, labelled form fields, skip link, `aria-hidden` icons, `aria-pressed`/`aria-expanded` on controls
- `prefers-reduced-motion` disables animations and smooth scroll

**Performance**
- `requestAnimationFrame`-throttled scroll handler with cached nodes
- Replaced Font Awesome CDN with an inline SVG sprite (one fewer render-blocking request)

**SEO**
- Canonical URL, Open Graph, Twitter Card, and `Person` JSON-LD structured data (canonical set to `https://jmbcs.github.io/portfolio/`)

## Verification

- Served locally (`python3 -m http.server`); all assets return 200
- JSON-LD validates; HTML tags balanced; no Font Awesome remnants; icon `use` refs resolve
- Note: no headless browser available in this environment, so the visual render and Lighthouse/responsive checks should be confirmed in a browser before marking ready

## Follow-ups (optional)
- Add a 1200×630 `imgs/og-card.png` and switch Twitter card to `summary_large_image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)